### PR TITLE
fix: spawn displays on main thread

### DIFF
--- a/src/main/kotlin/VisionActivityEntry.kt
+++ b/src/main/kotlin/VisionActivityEntry.kt
@@ -259,10 +259,12 @@ class VisionActivity(
 
     private fun spawnDisplay(point: org.bukkit.Location, viewer: Player) {
         val plugin = Bukkit.getPluginManager().getPlugin("Typewriter") ?: return
-        val display = viewer.world.spawn(point, ItemDisplay::class.java) { disp ->
-            disp.setItemStack(ItemStack(material))
-        }
-        Bukkit.getScheduler().runTaskLater(plugin, Runnable { display.remove() }, 1L)
+        Bukkit.getScheduler().runTask(plugin, Runnable {
+            val display = viewer.world.spawn(point, ItemDisplay::class.java) { disp ->
+                disp.setItemStack(ItemStack(material))
+            }
+            Bukkit.getScheduler().runTaskLater(plugin, Runnable { display.remove() }, 1L)
+        })
     }
 
     override fun dispose(context: ActivityContext) {}


### PR DESCRIPTION
## Summary
- spawn item displays using `runTask` to ensure spawning on main thread

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68b063448a8883209128811be59e9eee