### PR TITLE
Keep NPC looking at players during random patrol

### DIFF
--- a/src/main/kotlin/RandomPatrolVisionActivityEntry.kt
+++ b/src/main/kotlin/RandomPatrolVisionActivityEntry.kt
@@ -66,7 +66,10 @@ class RandomPatrolVisionActivity(
 ) : EntityActivity<ActivityContext> {
     override var currentPosition: PositionProperty
         get() = patrol.currentPosition
-        set(_) {}
+        set(value) {
+            patrol.currentPosition = value
+            vision.currentPosition = value
+        }
 
     override val currentProperties: List<EntityProperty>
         get() = patrol.currentProperties + vision.currentProperties
@@ -84,6 +87,8 @@ class RandomPatrolVisionActivity(
         } else {
             patrol.tick(context)
         }
+        patrol.currentPosition =
+            patrol.currentPosition.withRotation(vision.currentPosition.yaw, vision.currentPosition.pitch)
         return if (patrolResult == TickResult.CONSUMED || visionResult == TickResult.CONSUMED) {
             TickResult.CONSUMED
         } else {
@@ -154,8 +159,11 @@ class RandomPatrolActivity(
         activity = IdleActivity(oldPosition)
     }
 
-    override val currentPosition: PositionProperty
+    override var currentPosition: PositionProperty
         get() = activity.currentPosition
+        set(value) {
+            activity.currentPosition = value
+        }
 
     override val currentProperties: List<EntityProperty>
         get() = activity.currentProperties


### PR DESCRIPTION
## Summary
- Sync patrol and vision positions so NPC rotation updates from vision
- Rotate patrol position toward players each tick to maintain gaze
- Allow RandomPatrolActivity position to be set externally

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task ':test'. Cannot convert URL 'C:/Users/julie/Desktop/dev/plugins/Typewriter/extensions' to a file)*

------
https://chatgpt.com/codex/tasks/task_e_68b57b966810832097fe74cc2825e7c5