### PR TITLE
Stop patrol activity from fighting vision when NPC looks at player

### DIFF
--- a/src/main/kotlin/RandomPatrolVisionActivityEntry.kt
+++ b/src/main/kotlin/RandomPatrolVisionActivityEntry.kt
@@ -80,6 +80,7 @@ class RandomPatrolVisionActivity(
         vision.currentPosition = patrol.currentPosition
         val visionResult = vision.tick(context)
         val patrolResult = if (stopWhenLooking && vision.isSeeingPlayer) {
+            patrol.stop(context)
             TickResult.IGNORED
         } else {
             patrol.tick(context)
@@ -146,6 +147,14 @@ class RandomPatrolActivity(
         }
 
         return TickResult.CONSUMED
+    }
+
+    fun stop(context: ActivityContext) {
+        if (activity !is IdleActivity) {
+            val oldPosition = currentPosition
+            activity.dispose(context)
+            activity = IdleActivity(oldPosition)
+        }
     }
 
     override fun dispose(context: ActivityContext) {


### PR DESCRIPTION
## Summary
- halt current patrol activity when NPC sees a player
- add helper to stop patrol navigation

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task ':test'. Could not create task ':jar'. Cannot convert URL 'C:/Users/julie/Desktop/dev/plugins/Typewriter/extensions' to a file.)*

------
https://chatgpt.com/codex/tasks/task_e_68b57d0463a08320b5bce61358e8abc1