### PR TITLE
Preserve head rotation when NPC pauses during patrol

### DIFF
--- a/src/main/kotlin/RandomPatrolVisionActivityEntry.kt
+++ b/src/main/kotlin/RandomPatrolVisionActivityEntry.kt
@@ -77,7 +77,12 @@ class RandomPatrolVisionActivity(
     }
 
     override fun tick(context: ActivityContext): TickResult {
-        vision.currentPosition = patrol.currentPosition
+        val patrolPos = patrol.currentPosition
+        vision.currentPosition = if (vision.isSeeingPlayer) {
+            patrolPos.withRotation(vision.currentPosition.yaw, vision.currentPosition.pitch)
+        } else {
+            patrolPos
+        }
         val visionResult = vision.tick(context)
         val patrolResult = if (stopWhenLooking && vision.isSeeingPlayer) {
             patrol.stop(context)


### PR DESCRIPTION
## Summary
- avoid resetting orientation when vision detects a player during patrol

## Testing
- `./gradlew build` *(fails: Cannot convert URL 'C:/Users/julie/Desktop/dev/plugins/Typewriter/extensions' to a file)*

------
https://chatgpt.com/codex/tasks/task_e_68b57e9068ec8320b65050dc90e510d8